### PR TITLE
Max Year Impl and Start Year fix

### DIFF
--- a/src/MonthPickerInput.tsx
+++ b/src/MonthPickerInput.tsx
@@ -26,6 +26,7 @@ export interface IProps {
     name?: string,
     id?: string,
   },
+  maxYear?: number,
   startYear?: number,
   lang?: string,
   onChange?: OnChange,
@@ -55,7 +56,7 @@ class MonthPickerInput extends Component<IProps, IState> {
 
   constructor(props) {
     super(props);
-    const { year, month, startYear} = this.props;
+    const { year, month, maxYear, startYear} = this.props;
     let inputValue = '';
 
     this.t = new Translator(this.props.lang, this.props.i18n);
@@ -64,6 +65,7 @@ class MonthPickerInput extends Component<IProps, IState> {
     this.state = {
       year,
       month,
+      maxYear,
       startYear,
       inputValue: this.valuesToMask(month, year),
       showCalendar: false,
@@ -141,13 +143,14 @@ class MonthPickerInput extends Component<IProps, IState> {
   };
 
   calendar = (): JSX.Element => {
-    const { year, month, startYear } = this.state;
+    const { year, month, maxYear, startYear } = this.state;
 
     return (
       <div style={{ position: 'relative' }}>
         <MonthCalendar
           year={year}
           month={month}
+          maxYear={maxYear}
           startYear={startYear}
           onChange={this.onCalendarChange}
           onOutsideClick={this.onCalendarOutsideClick}

--- a/src/MonthPickerInput.tsx
+++ b/src/MonthPickerInput.tsx
@@ -26,6 +26,7 @@ export interface IProps {
     name?: string,
     id?: string,
   },
+  startYear?: number,
   lang?: string,
   onChange?: OnChange,
   closeOnSelect?: boolean,
@@ -54,7 +55,7 @@ class MonthPickerInput extends Component<IProps, IState> {
 
   constructor(props) {
     super(props);
-    const { year, month } = this.props;
+    const { year, month, startYear} = this.props;
     let inputValue = '';
 
     this.t = new Translator(this.props.lang, this.props.i18n);
@@ -63,6 +64,7 @@ class MonthPickerInput extends Component<IProps, IState> {
     this.state = {
       year,
       month,
+      startYear,
       inputValue: this.valuesToMask(month, year),
       showCalendar: false,
     }
@@ -139,13 +141,14 @@ class MonthPickerInput extends Component<IProps, IState> {
   };
 
   calendar = (): JSX.Element => {
-    const { year, month } = this.state;
+    const { year, month, startYear } = this.state;
 
     return (
       <div style={{ position: 'relative' }}>
         <MonthCalendar
           year={year}
           month={month}
+          startYear={startYear}
           onChange={this.onCalendarChange}
           onOutsideClick={this.onCalendarOutsideClick}
           translator={this.t}

--- a/src/calendar/MonthCalendar.tsx
+++ b/src/calendar/MonthCalendar.tsx
@@ -37,7 +37,7 @@ class MonthCalendar extends Component<IProps, IState> {
 
     const { year, month } = this.props;
 
-    let startYear = this.getNormalizedStartYear(this.props.startYear) || new Date().getFullYear() - 6;
+    let startYear = this.getNormalizedStartYear(this.props.startYear);
 
     this.t = this.props.translator;
 
@@ -106,7 +106,9 @@ class MonthCalendar extends Component<IProps, IState> {
   }
 
   getNormalizedStartYear = (startYear: number): number => {
-    return this.props.maxYear && (startYear + 12) > this.props.maxYear ? this.props.maxYear - 11 : startYear;
+    startYear = startYear || new Date().getFullYear() - 6;
+    if (this.props.maxYear === undefined) return startYear;
+    return startYear + 11 > this.props.maxYear ? this.props.maxYear - 11 : startYear;
   }
 
   updateYears = (startYear: number): void => {

--- a/src/calendar/MonthCalendar.tsx
+++ b/src/calendar/MonthCalendar.tsx
@@ -11,6 +11,7 @@ export interface IProps {
   year: void|number,
   month: void|number,
   startYear?: number,
+  maxYear?: number,
   onChange: (selectedYear: number, selectedMonth: number) => any,
   onOutsideClick: (e: any) => any,
   translator: Translator,
@@ -36,7 +37,7 @@ class MonthCalendar extends Component<IProps, IState> {
 
     const { year, month } = this.props;
 
-    const startYear = this.props.startYear || new Date().getFullYear() - 6;
+    let startYear = this.getNormalizedStartYear(this.props.startYear) || new Date().getFullYear() - 18;
 
     this.t = this.props.translator;
 
@@ -104,8 +105,12 @@ class MonthCalendar extends Component<IProps, IState> {
     this.setState({ currentView: VIEW_YEARS });
   }
 
+  getNormalizedStartYear = (startYear: number): number => {
+    return this.props.maxYear && (startYear + 12) > this.props.maxYear ? this.props.maxYear - 11 : startYear;
+  }
+
   updateYears = (startYear: number): void => {
-    const years = Array.from({length: 12}, (v, k) => k + startYear);
+    const years = Array.from({length: 12}, (v, k) => k + this.getNormalizedStartYear(startYear));
 
     this.setState({ years, currentView: VIEW_YEARS });
   }

--- a/src/calendar/MonthCalendar.tsx
+++ b/src/calendar/MonthCalendar.tsx
@@ -37,7 +37,7 @@ class MonthCalendar extends Component<IProps, IState> {
 
     const { year, month } = this.props;
 
-    let startYear = this.getNormalizedStartYear(this.props.startYear) || new Date().getFullYear() - 18;
+    let startYear = this.getNormalizedStartYear(this.props.startYear) || new Date().getFullYear() - 6;
 
     this.t = this.props.translator;
 


### PR DESCRIPTION
MonthPickerInput didn't send startYear property, so MonthCalendar never received it.

Implemented maxYear property, so now calendar can be limited by max year